### PR TITLE
"No!" edgecase fix

### DIFF
--- a/steps.py
+++ b/steps.py
@@ -20,7 +20,8 @@ def clarify(ai: AI, dbs: DBs):
     while True:
         messages = ai.next(messages, user)
 
-        if messages[-1]['content'].strip().lower() == 'no':
+        latest_message_content = messages[-1]['content'].strip().lower()
+        if latest_message_content.startswith('no') and len(latest_message_content) < 5:
             break
 
         print()


### PR DESCRIPTION
Fixed an issue where ChatGPT says "no!" instead of just "no". The startswith in combination with the len fixes this edgecase. 
(the len() makes sure that it doesnt think its "no" when GPT starts with "nothing" or some other sentence with these two letters)