### PR TITLE
Add `python-dotenv`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ GPT Engineer is made to be easy to adapt, extend, and make your agent learn how 
 **Setup**:
 - `pip install -r requirements.txt`
 - `export OPENAI_API_KEY=[your api key]` with a key that has GPT4 access
+or
+- Copy [.env.example](./.env.example) and rename to `.env`. Save your `OPENAI_API_KEY` in this file.
 
 **Run**:
 - Create a new empty folder with a `main_prompt` file (or copy the example folder `cp -r example/ my-new-project`)

--- a/gpt_engineer/main.py
+++ b/gpt_engineer/main.py
@@ -2,6 +2,8 @@ import os
 import json
 import pathlib
 import typer
+from dotenv import load_dotenv
+load_dotenv()
 
 from gpt_engineer.chat_to_files import to_files
 from gpt_engineer.ai import AI

--- a/identity/generate
+++ b/identity/generate
@@ -11,6 +11,6 @@ Before you finish, double check that all parts of the architecture is present in
 
 File syntax:
 
-```file.py/ts/html
+```file.py/file.ts/file.js/file.html
 [ADD YOUR CODE HERE]
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai==0.27.8
 pre-commit==3.3.3
 ruff==0.0.272
 typer==0.9.0
+python-dotenv==1.0.0


### PR DESCRIPTION
1. Provide `.env` support to manage API keys.
2. Slight update to `identity/generate` which allows for the correct GPT filename output for non-python files. (i.e. before js files were being named `javascript`)