### PR TITLE
Benchmark is set to work as a standalone shape

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -6,12 +6,13 @@ import subprocess
 
 from itertools import islice
 from pathlib import Path
+from typing import Optional
 
 from typer import run
 
 
 def main(
-    n_benchmarks: int | None = None,
+    n_benchmarks: Optional[int] = None,
 ):
     path = Path("benchmark")
 


### PR DESCRIPTION
It does not require a qualifier as it is optional. Also in the system `n_benchmarks: int | None = None` was incorrect and the debugger was saying it was a mistake. I fixed the code directory to Optional.