### PR TITLE
Fix square bracket file name issue

### DIFF
--- a/gpt_engineer/chat_to_files.py
+++ b/gpt_engineer/chat_to_files.py
@@ -11,6 +11,9 @@ def parse_chat(chat):  # -> List[Tuple[str, str]]:
         # Strip the filename of any non-allowed characters and convert / to \
         path = re.sub(r'[<>"|?*]', "", match.group(1))
 
+        # Remove leading and trailing brackets
+        path = re.sub(r"^\[(.*)\]$", r"\1", path)
+
         # Get the code
         code = match.group(2)
 

--- a/tests/test_chat_to_files.py
+++ b/tests/test_chat_to_files.py
@@ -1,0 +1,94 @@
+import textwrap
+
+from gpt_engineer.chat_to_files import to_files
+
+
+def test_to_files():
+    chat = textwrap.dedent(
+        """
+    This is a sample program.
+
+    file1.py
+    ```python
+    print("Hello, World!")
+    ```
+
+    file2.py
+    ```python
+    def add(a, b):
+        return a + b
+    ```
+    """
+    )
+
+    workspace = {}
+    to_files(chat, workspace)
+
+    assert workspace["all_output.txt"] == chat
+
+    expected_files = {
+        "file1.py": 'print("Hello, World!")\n',
+        "file2.py": "def add(a, b):\n    return a + b\n",
+        "README.md": "\nThis is a sample program.\n\nfile1.py\n",
+    }
+
+    for file_name, file_content in expected_files.items():
+        assert workspace[file_name] == file_content
+
+
+def test_to_files_with_square_brackets():
+    chat = textwrap.dedent(
+        """
+    This is a sample program.
+
+    [file1.py]
+    ```python
+    print("Hello, World!")
+    ```
+
+    [file2.py]
+    ```python
+    def add(a, b):
+        return a + b
+    ```
+    """
+    )
+    workspace = {}
+    to_files(chat, workspace)
+
+    assert workspace["all_output.txt"] == chat
+
+    expected_files = {
+        "file1.py": 'print("Hello, World!")\n',
+        "file2.py": "def add(a, b):\n    return a + b\n",
+        "README.md": "\nThis is a sample program.\n\n[file1.py]\n",
+    }
+
+    for file_name, file_content in expected_files.items():
+        assert workspace[file_name] == file_content
+
+
+def test_files_with_brackets_in_name():
+    chat = textwrap.dedent(
+        """
+    This is a sample program.
+
+    [id].jsx
+    ```javascript
+    console.log("Hello, World!")
+    ```
+    """
+    )
+
+    workspace = {}
+    to_files(chat, workspace)
+
+    assert workspace["all_output.txt"] == chat
+
+    expected_files = {
+        "[id].jsx": 'console.log("Hello, World!")\n',
+        "README.md": "\nThis is a sample program.\n\n[id].jsx\n",
+    }
+
+    for file_name, file_content in expected_files.items():
+        assert workspace[file_name] == file_content


### PR DESCRIPTION
Fixes an issue where file names surrounded by `[]` would not be stripped out properly in creating the file name. Also added some tests.

Handles the following cases
- [code.py] => code.py
- [id].jsx => [id].jsx

Fixes #169 