### PR TITLE
fix(bug): toml misconfiguration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   'black == 23.3.0',
   'openai == 0.27.8',
   'ruff == 0.0.272',
+  'pre-commit == 3.3.3',
   'typer == 0.9.0'
 ]
 


### PR DESCRIPTION
"pre-commit: command not found" was generated upon clean codepsace; "pre-commit" was in /requirements.txt, but missing in .toml file.

**Steps to reproduce**
- create default Codespace 
- run `make install`
- See error: `pre-commit: command not found`