### PR TITLE
Handle newlines between filename

### DIFF
--- a/gpt_engineer/chat_to_files.py
+++ b/gpt_engineer/chat_to_files.py
@@ -3,7 +3,7 @@ import re
 
 def parse_chat(chat):  # -> List[Tuple[str, str]]:
     # Get all ``` blocks and preceding filenames
-    regex = r"(\S+?)\n```\S+\n(.+?)```"
+    regex = r"(\S+)\n\s*```[^\n]*\n(.+?)```"
     matches = re.finditer(regex, chat, re.DOTALL)
 
     files = []

--- a/tests/test_chat_to_files.py
+++ b/tests/test_chat_to_files.py
@@ -144,3 +144,57 @@ def test_files_with_back_tick():
 
     for file_name, file_content in expected_files.items():
         assert workspace[file_name] == file_content
+
+
+def test_files_with_newline_between():
+    chat = textwrap.dedent(
+        """
+    This is a sample program.
+
+    file1.py
+
+    ```python
+    print("Hello, World!")
+    ```
+    """
+    )
+
+    workspace = {}
+    to_files(chat, workspace)
+
+    assert workspace["all_output.txt"] == chat
+
+    expected_files = {
+        "file1.py": 'print("Hello, World!")\n',
+        "README.md": "\nThis is a sample program.\n\nfile1.py\n\n",
+    }
+
+    for file_name, file_content in expected_files.items():
+        assert workspace[file_name] == file_content
+
+
+def test_files_with_newline_between_header():
+    chat = textwrap.dedent(
+        """
+    This is a sample program.
+
+    ## file1.py
+
+    ```python
+    print("Hello, World!")
+    ```
+    """
+    )
+
+    workspace = {}
+    to_files(chat, workspace)
+
+    assert workspace["all_output.txt"] == chat
+
+    expected_files = {
+        "file1.py": 'print("Hello, World!")\n',
+        "README.md": "\nThis is a sample program.\n\n## file1.py\n\n",
+    }
+
+    for file_name, file_content in expected_files.items():
+        assert workspace[file_name] == file_content


### PR DESCRIPTION
I ran through the benchmark tests after the switch to simple, and it used `##` headings more commonly for me on generating the file contents. 

>     This is a sample program.
> 
>     ## file1.py
> 
>     ```python
>     print("Hello, World!")
>     ```

Adds two tests and handles the newline