### PR TITLE
enabled compatiblilty with python versions <3.9 fixes #253

### DIFF
--- a/gpt_engineer/ai.py
+++ b/gpt_engineer/ai.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import openai


### PR DESCRIPTION
I included **from __future__ import annotations** at the top of the **gpt_engineer/ai.py** file to enable support for python versions <3.9 when running **gpt-engineer $(project)**