### PR TITLE
fix: model name to gpt-3.5-turbo

### DIFF
--- a/gpt_engineer/main.py
+++ b/gpt_engineer/main.py
@@ -19,7 +19,7 @@ app = typer.Typer()
 def main(
     project_path: str = typer.Argument("example", help="path"),
     delete_existing: bool = typer.Argument(False, help="delete existing files"),
-    model: str = "gpt-4",
+    model: str = "gpt-3.5-turbo",
     temperature: float = 0.1,
     steps_config: steps.Config = typer.Option(
         steps.Config.DEFAULT, "--steps", "-s", help="decide which steps to run"


### PR DESCRIPTION
Gpt4 is an incorrect model name also it is not widely available. So i have added most common used model 'gpt-3.5-turbo' as default one