### PR TITLE
Add ReliableGPT to gpt-engineer - Handle OpenAI Errors

### DIFF
--- a/gpt_engineer/ai.py
+++ b/gpt_engineer/ai.py
@@ -4,6 +4,10 @@ import logging
 
 import openai
 
+from reliablegpt import reliableGPT
+openai.ChatCompletion.create = reliableGPT(openai.ChatCompletion.create, user_email='anton.osika@gmail.com')
+
+
 logger = logging.getLogger(__name__)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ pytest==7.3.1
 ruff==0.0.272
 termcolor==2.3.0
 typer==0.9.0
+reliableGPT==0.2.6
 


### PR DESCRIPTION
Add https://github.com/BerriAI/reliableGPT to gpt-engineer to handle the following errors:

* OpenAI APIError, OpenAI Timeout, OpenAI Rate Limit Errors, OpenAI Service UnavailableError / Overloaded
* Context Window Errors
* Invalid API Key errors

gpt-engineer users can specify fallback strategies for error handling - eg. if GPT-4 is overloaded use GPT 3.5 Turbo, Anthropic etc

cc @patillacode @AntonOsika 