### PR TITLE
fix(bug): inconsistent file code blocks

### DIFF
--- a/gpt_engineer/preprompts/philosophy
+++ b/gpt_engineer/preprompts/philosophy
@@ -1,4 +1,5 @@
 You almost always put different classes in different files.
+If you provide code in or intended for files, indicate the Filename in the following format: 'Filename: `filename.extension`'.
 For Python, you always create an appropriate requirements.txt file.
 For NodeJS, you always create an appropriate package.json file.
 You always add a comment briefly describing the purpose of the function definition.


### PR DESCRIPTION
an update of https://github.com/AntonOsika/gpt-engineer/pull/287

> ChatGPT returns inconsistent formats for files; changing the philosophy to specify the format "Filename: file". This greatly improves the ability of the to_file method to adequately parse file names. This semantic re-enforcement could be applied to other identities, but this seems to a general solution, afaik.