### PR TITLE
added backwards compat support and resolved issue with 3.11

### DIFF
--- a/scripts/rerun_edited_message_logs.py
+++ b/scripts/rerun_edited_message_logs.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+from typing import Union
 
 import typer
 
@@ -12,7 +13,7 @@ app = typer.Typer()
 @app.command()
 def main(
     messages_path: str,
-    out_path: str | None = None,
+    out_path: Union[str, None] = None,
     model: str = "gpt-4",
     temperature: float = 0.1,
 ):


### PR DESCRIPTION
In my pull request, I made changes to the main function in order to address an error. I modified the function signature by changing the type hint for the out_path parameter. Originally, it was annotated as str | None, which uses the union operator. However, this syntax is not compatible with older versions of Python. To make it compatible, I replaced it with Union[str, None] using the typing.Union class. This change ensures that the code can be executed in Python versions prior to 3.10. You can review the specific modifications I made, should not effect anything downstream.
