### PR TITLE
add NodeJs toolbelt in `philosophy` file

### DIFF
--- a/gpt_engineer/preprompts/philosophy
+++ b/gpt_engineer/preprompts/philosophy
@@ -10,3 +10,7 @@ package/project.
 Python toolbelt preferences:
 - pytest
 - dataclasses
+
+NodeJS toolbelt preferences:
+- jest
+- supertest


### PR DESCRIPTION
- jest https://jestjs.io
- supertest https://github.com/ladjs/supertest

this is mainly for backend Nodejs projects

If we want to add TDD toolbelt on React (front-end projects) each might have its preferred 