### PR TITLE
Clarify missing files error message.

### DIFF
--- a/gpt_engineer/db.py
+++ b/gpt_engineer/db.py
@@ -18,7 +18,7 @@ class DB:
         full_path = self.path / key
 
         if not full_path.is_file():
-            raise KeyError(key)
+            raise KeyError(f"File '{key}' could not be found in '{self.path}'")
         with full_path.open("r", encoding="utf-8") as f:
             return f.read()
 


### PR DESCRIPTION
What do you think in clarify the error message when missing a file? I had trouble understanding what was wrong when I missed some files such as the prompt "main_prompt" or the "feedback" file. 

This commit changes the error message to help the user understand what needs to be done to execute the program correctly. 

ie. When missing the "feedback" file, the error before this commit was:

`KeyError: 'feedback'`

and now is:

`KeyError: "File 'feedback' could not be found in 'C:\\xxx\\xxxx\\gpt-engineer\\projects\\test'"`

As shows figure above:

![cmd_5MnGbGSMbT](https://github.com/AntonOsika/gpt-engineer/assets/11357793/cc3a579e-1bb5-4904-9c98-48e897f2636d)
