### PR TITLE
Allow using Azure OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ With an api key that has GPT4 access run:
 
 By running gpt-engineer you agree to our [terms](https://github.com/AntonOsika/gpt-engineer/blob/main/TERMS_OF_USE.md).
 
+
+- Run with other models:
+  - Azure OpenAI
+    - use `gpt-engineer projects/my-new-project --azure --engine your_model_name`
+    - this requires these environment variables: `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_KEY` and optionally `AZURE_API_VERSION`
+
 **Results**
 - Check the generated files in `projects/my-new-project/workspace`
 

--- a/gpt_engineer/ai.py
+++ b/gpt_engineer/ai.py
@@ -23,9 +23,12 @@ class AI:
                 raise ValueError("To use Azure OpenAI models please set a "
                                 "AZURE_OPENAI_KEY enviroment variable.") 
     
+            if api_version := os.getenv("AZURE_API_VERSION") is None:
+                openai.api_version = "2023-05-15"
+            else:
+                openai.api_version = api_version
             openai.api_type = "azure"
             openai.api_base = os.getenv("AZURE_OPENAI_ENDPOINT") 
-            openai.api_version = "2023-05-15"
             openai.api_key = os.getenv("AZURE_OPENAI_KEY")
 
 

--- a/gpt_engineer/main.py
+++ b/gpt_engineer/main.py
@@ -31,8 +31,14 @@ def main(
             "run prefix, if you want to run multiple variants of the same project and "
             "later compare them"
         ),
-    ),
+    ),    
+    is_azure: bool = typer.Option(False, "--azure", help="use Azure OpenAI"),
+    engine: str = typer.Option(None, help="model name as defined in "
+                               "azure opanai studio"),
 ):
+    if is_azure and not engine:
+        raise typer.Exit("When using --azure, you must provide an --engine argument.")
+
     logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
 
     input_path = Path(project_path).absolute()
@@ -44,11 +50,15 @@ def main(
         shutil.rmtree(memory_path, ignore_errors=True)
         shutil.rmtree(workspace_path, ignore_errors=True)
 
-    model = fallback_model(model)
+    if is_azure:
+        model = engine
+    else: 
+        model = fallback_model(model)
 
     ai = AI(
         model=model,
         temperature=temperature,
+        is_azure=is_azure
     )
 
     dbs = DBs(


### PR DESCRIPTION
Allows using Azure OpenAI instead of OpenAI (solves #325)
```
gpt-engineer [project_path] --azure --engine [your_azureopenai_model_name]
```

To be consistent with Azure OpenAI terminology, the model is called an `engine` instead.

Requires to set `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_KEY` as environment variables.