### PR TITLE
Bug Fix: Model Name Should Not Be Verified Through OpenAI with Custom Endpoint

### DIFF
--- a/gpt_engineer/main.py
+++ b/gpt_engineer/main.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import typer
 
 from gpt_engineer import steps
-from gpt_engineer.ai import AI, fallback_model
+from gpt_engineer.ai import AI
 from gpt_engineer.collect import collect_learnings
 from gpt_engineer.db import DB, DBs
 from gpt_engineer.steps import STEPS
@@ -44,7 +44,6 @@ def main(
         shutil.rmtree(memory_path, ignore_errors=True)
         shutil.rmtree(workspace_path, ignore_errors=True)
 
-    model = fallback_model(model)
 
     ai = AI(
         model=model,


### PR DESCRIPTION
Closes #331

## Overview
This Pull Request aims to fix the bug that prevents setting custom API endpoint.

## Background
Many open-source LLMs (e.g. FastChat, ChatGLM) provides OpenAI-compatible APIs, which means once these models are set up and running locally, users should be able to query them, still via ```openai.ChatCompletion.create()```,  simply by setting ```export OPENAI_API_BASE=<where model is running>```. However the current version of GPT-Engineer attempts to verify model name through OpenAI even if a custom api base is set.

## Changes 
* Modified such that model name is only verified (by ```fallback_model()```) only if a custom ```OPENAI_API_BASE``` is not set.
 