### PR TITLE
refactor(makefile): :recycle: remove repetitive command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COLOR_RESET=\033[0m
 COLOR_CYAN=\033[1;36m
 COLOR_GREEN=\033[1;32m
 
-.PHONY: help install dev-install run
+.PHONY: help install run
 
 .DEFAULT_GOAL := help
 
@@ -17,10 +17,7 @@ help:
 	@echo "Please use 'make <target>' where <target> is one of the following:"
 	@echo "  help           	Return this message with usage instructions."
 	@echo "  install        	Will install the dependencies and create a virtual environment."
-	@echo "  dev-install    	Will install the dev dependencies too."
 	@echo "  run <folder_name>  Runs GPT Engineer on the folder with the given name."
-
-dev-install: install
 
 install: create-venv upgrade-pip install-dependencies install-pre-commit farewell
 


### PR DESCRIPTION
Removing repetitive command `dev-install` because it does the same as `install`. Does not matter if you run `make install` or `make dev-install`, both do the same thing.