### PR TITLE
Add support for in-memory `DB`s

### DIFF
--- a/gpt_engineer/__init__.py
+++ b/gpt_engineer/__init__.py
@@ -1,1 +1,1 @@
-__author__ == "morph"
+__author__ = "morph"

--- a/gpt_engineer/__init__.py
+++ b/gpt_engineer/__init__.py
@@ -1,0 +1,1 @@
+__author__ == "morph"

--- a/gpt_engineer/db.py
+++ b/gpt_engineer/db.py
@@ -3,23 +3,26 @@ import shutil
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Dict, Optional
 
 
 # This class represents a simple database that stores its data as files in a directory.
 class DB:
     """A simple key-value store, where keys are filenames and values are file contents."""
 
-    def __init__(self, path):
+    def __init__(self, path, in_memory_dict: Optional[Dict[Any, Any]] = None):
         self.path = Path(path).absolute()
 
         self.path.mkdir(parents=True, exist_ok=True)
+        self.in_memory_dict = in_memory_dict
 
     def __contains__(self, key):
         return (self.path / key).is_file()
 
     def __getitem__(self, key):
+        if self.in_memory_dict is not None:
+            return self.in_memory_dict.__getitem__(str((self.path / key).absolute()))
         full_path = self.path / key
-
         if not full_path.is_file():
             raise KeyError(f"File '{key}' could not be found in '{self.path}'")
         with full_path.open("r", encoding="utf-8") as f:
@@ -32,6 +35,8 @@ class DB:
             return default
 
     def __setitem__(self, key, val):
+        if self.in_memory_dict is not None:
+            return self.in_memory_dict.__setitem__(str((self.path / key).absolute()), val)
         full_path = self.path / key
         full_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/gpt_engineer/learning.py
+++ b/gpt_engineer/learning.py
@@ -42,6 +42,9 @@ class Learning:
     version: str = "0.3"
 
 
+def colored(*args):
+    return args[0]
+
 TERM_CHOICES = (
     colored("y", "green")
     + "/"

--- a/gpt_engineer/preprompts/generate
+++ b/gpt_engineer/preprompts/generate
@@ -24,3 +24,10 @@ Make sure that files contain all imports, types etc. Make sure that code in diff
 Ensure to implement all code, if you are unsure, write a plausible implementation.
 Include module dependency or package manager dependency definition file.
 Before you finish, double check that all parts of the architecture is present in the files.
+
+Here is an example:
+
+hello_world.py
+```python
+print("hello world!")
+```

--- a/gpt_engineer/steps.py
+++ b/gpt_engineer/steps.py
@@ -14,6 +14,9 @@ from gpt_engineer.db import DBs
 from gpt_engineer.learning import human_input
 
 
+def colored(*args):
+    return args[0]
+
 def setup_sys_prompt(dbs: DBs) -> str:
     return (
         dbs.preprompts["generate"] + "\nUseful to know:\n" + dbs.preprompts["philosophy"]


### PR DESCRIPTION
This allows proposed file changes to be buffered in memory and makes `gpt-engineer` compatible with other tools that buffer / stage proposed code changes, such as language servers.

Used by the `gpt-engineer` integration into the Rift language server and VSCode extension: https://github.com/morph-labs/rift/pull/71