### PR TITLE
Added Gpt-engineer colab notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # GPT Engineer
 
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1L2j_zAukJckNEMzlpvgvi44W_SC8Z0w2?usp=sharing)
 [![Discord Follow](https://dcbadge.vercel.app/api/server/8tcDQ89Ej2?style=flat)](https://discord.gg/8tcDQ89Ej2)
 [![GitHub Repo stars](https://img.shields.io/github/stars/AntonOsika/gpt-engineer?style=social)](https://github.com/AntonOsika/gpt-engineer)
 [![Twitter Follow](https://img.shields.io/twitter/follow/antonosika?style=social)](https://twitter.com/AntonOsika)


### PR DESCRIPTION
Run Gpt-engineer on Google Colab in your browser.
It will make user's to try it in their browser before they run it in local system.