### PR TITLE
Add benchmark Results for commit 8358b60 with GPT3.5-default

### DIFF
--- a/benchmark/RESULTS.md
+++ b/benchmark/RESULTS.md
@@ -4,6 +4,29 @@
 python scripts/benchmark.py
 ```
 
+## 2023-08-20 (8358b60e1c6dcfc517c47c15708422d9a7d1d83a)
+| Benchmark          | Version       | Ran | Works | Perfect |
+|--------------------|---------------|-----|-------|---------|
+| currency_converter | GPT3.5 default| ✅  | ❌    | ❌       |
+| image_resizer      | GPT3.5 default| ✅  | ✅    | ✅      |
+| pomodoro_timer     | GPT3.5 default| ✅  | ✅    | ❌      |
+| url_shortener      | GPT3.5 default| ❌  | ❌    | ❌      |
+| file_explorer      | GPT3.5 default| ✅  | ✅    | ❌      |
+| markdown_editor    | GPT3.5 default| ✅  | ❌    | ❌      |
+| timer_app          | GPT3.5 default| ✅  | ✅    | ✅      |
+| file_organizer     | GPT3.5 default| ✅  | ✅    | ❌      |
+| password_generator | GPT3.5 default| ✅  | ✅    | ✅      |
+| todo_list          | GPT3.5 default| ✅  | ✅    | ❌      |
+
+### Notes on the errors
+
+#### GPT3.5
+- `pomodoro_timer`: notifications didn't work.
+- `file_explorer`: deletion didn't work.
+- `file_organizer`: only handled a very small set of formats.
+- `todo_list`: tasks couldn't be marked as completed.
+- `url_shortener`: file names were wrong. Nothing could be run.
+
 ## 2023-06-21
 
 | Benchmark          | Ran | Works | Perfect |


### PR DESCRIPTION
**Issue Addressed**: [#596](https://github.com/AntonOsika/gpt-engineer/issues/596)

**Summary**: 
This PR provides benchmark results for the GPT3.5 with default configurations. This serves as a reference for comparing with results from TDD configurations in the future.

**Changes**:
1. Ran benchmarks on GPT3.5 (default configurations) - Note: I don't have access to GPT4.
2. Documented the results for reference.

**Next Steps**:
Running the benchmarks and checking the results is time-consuming. In a subsequent effort, I plan to run the benchmarks with TDD configurations and compare the outcomes. If someone wishes to undertake this before I get to it, we now have a reference benchmark to compare against.
