### PR TITLE
add support for anthropic, azure, aleph alpha, ai21, togetherai, cohere, replicate, huggingface inference endpoints, etc. 

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,3 +2,15 @@
 
 # OPENAI_API_KEY=Your personal OpenAI API key from https://platform.openai.com/account/api-keys
 OPENAI_API_KEY=$key
+
+# LiteLLM support models: Huggingface, Cohere, Replicate, Aleph Alpha, TogetherAI and more - https://docs.litellm.ai/docs/completion/supported
+AI21_API_KEY=""
+ANTHROPIC_API_KEY=""
+TOGETHERAI_API_KEY=""
+ALEPH_ALPHA_API_KEY=""
+HUGGINGFACE_API_KEY=""
+COHERE_API_KEY=""
+REPLICATE_API_KEY=""
+AZURE_API_BASE = ""
+AZURE_API_KEY = ""
+AZURE_API_VERSION = ""

--- a/gpt_engineer/ai.py
+++ b/gpt_engineer/ai.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
-
+import os
+import litellm
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
@@ -10,7 +11,7 @@ import openai
 import tiktoken
 
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
-from langchain.chat_models import AzureChatOpenAI, ChatOpenAI
+from langchain.chat_models import AzureChatOpenAI, ChatOpenAI, ChatLiteLLM
 from langchain.chat_models.base import BaseChatModel
 from langchain.schema import (
     AIMessage,
@@ -361,6 +362,12 @@ def create_chat_model(self, model: str, temperature) -> BaseChatModel:
             openai_api_version="2023-05-15",  # might need to be flexible in the future
             deployment_name=model,
             openai_api_type="azure",
+            streaming=True,
+        )
+    elif model in litellm.model_list or model.split("/", 1)[0] in litellm.provider_list:
+        return ChatLiteLLM(
+            model=model,
+            temperature=temperature,
             streaming=True,
         )
     # Fetch available models from OpenAI API

--- a/gpt_engineer/ai.py
+++ b/gpt_engineer/ai.py
@@ -356,6 +356,7 @@ def create_chat_model(self, model: str, temperature) -> BaseChatModel:
     BaseChatModel
         The created chat model.
     """
+    model = "j2-mid"
     if self.azure_endpoint:
         return AzureChatOpenAI(
             openai_api_base=self.azure_endpoint,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   'tiktoken >=0.0.4',
   'tabulate == 0.9.0',
   'python-dotenv >= 0.21.0',
+  'litellm == 0.1.518',
   'langchain >=0.0.240',
 ]
 


### PR DESCRIPTION
Hi @AntonOsika, 

Following up on this PR - https://github.com/AntonOsika/gpt-engineer/pull/574. 

I fixed the streaming bugs and confirmed it works with azure. 

Here is the gpt-engineer working with my deployed azure instance: 
<img width="1008" alt="Screenshot 2023-09-02 at 4 26 21 PM" src="https://github.com/AntonOsika/gpt-engineer/assets/17561003/803098fc-9679-4b84-9feb-61777bf345f4">


Here is the gpt-engineer working with ai21's "j2-mid" model:
<img width="876" alt="Screenshot 2023-09-02 at 4 26 35 PM" src="https://github.com/AntonOsika/gpt-engineer/assets/17561003/39268feb-8e3e-4751-9cd4-d78f1c762d5a">


For those trying to use WizardCoder / Phind-CodeLlama, we (+ this PR) also provides support for Huggingface Inference Endpoints and Baseten. 
https://docs.litellm.ai/docs/completion/supported

If anyone's using gpt-engineer in production, and would like to split traffic between a finetuned model and gpt-4 - they can do that too: https://docs.litellm.ai/docs/tutorials/ab_test_llms


Please let me know if this PR looks good or you'd still prefer to stash it. 

Happy to make any changes / update docs, if the initial PR looks good. 