### PR TITLE
Simplify which folders are used

### DIFF
--- a/gpt_engineer/db.py
+++ b/gpt_engineer/db.py
@@ -139,8 +139,3 @@ def archive(dbs: DBs) -> None:
     shutil.move(
         str(dbs.memory.path), str(dbs.archive.path / timestamp / dbs.memory.path.name)
     )
-    shutil.move(
-        str(dbs.workspace.path),
-        str(dbs.archive.path / timestamp / dbs.workspace.path.name),
-    )
-    return []

--- a/gpt_engineer/main.py
+++ b/gpt_engineer/main.py
@@ -48,12 +48,6 @@ def main(
 ):
     logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
 
-    # For the improve option take current project as path and add .gpteng folder
-    if improve_option:
-        # The default option for the --improve is the IMPROVE_CODE, not DEFAULT
-        if steps_config == StepsConfig.DEFAULT:
-            steps_config = StepsConfig.IMPROVE_CODE
-
     load_env_if_needed()
 
     ai = AI(
@@ -62,10 +56,11 @@ def main(
         azure_endpoint=azure_endpoint,
     )
 
-    input_path = Path(project_path).absolute()
-    memory_path = input_path / "memory"
-    workspace_path = input_path / "workspace"
-    archive_path = input_path / "archive"
+    path = Path(project_path).absolute()
+    input_path = path
+    workspace_path = path
+    memory_path = path / ".gpteng" / "memory"
+    archive_path = path / ".gpteng" / "archive"
 
     dbs = DBs(
         memory=DB(memory_path),
@@ -77,6 +72,12 @@ def main(
         ),  # Loads preprompts from the preprompts directory
         archive=DB(archive_path),
     )
+
+    # For the improve option take current project as path and add .gpteng folder
+    if improve_option:
+        # The default option for the --improve is the IMPROVE_CODE, not DEFAULT
+        if steps_config == StepsConfig.DEFAULT:
+            steps_config = StepsConfig.IMPROVE_CODE
 
     if steps_config not in [
         StepsConfig.EXECUTE_ONLY,

--- a/tests/steps/test_archive.py
+++ b/tests/steps/test_archive.py
@@ -13,13 +13,14 @@ def freeze_at(monkeypatch, time):
 
 
 def setup_dbs(tmp_path, dir_names):
-    directories = [tmp_path / name for name in dir_names]
+    directories = {name: tmp_path / name for name in dir_names}
 
     # Create DB objects
-    dbs = [DB(dir) for dir in directories]
+    dbs = {k: DB(dir) for k, dir in directories.items()}
 
     # Create DBs instance
-    return DBs(*dbs)
+
+    return DBs(**dbs)
 
 
 def test_archive(tmp_path, monkeypatch):
@@ -31,7 +32,9 @@ def test_archive(tmp_path, monkeypatch):
     assert not os.path.exists(tmp_path / "memory")
     assert os.path.isdir(tmp_path / "archive" / "20201225_170555")
 
-    dbs = setup_dbs(tmp_path, ["memory", "logs", "preprompts", "input", "archive"])
+    dbs = setup_dbs(
+        tmp_path, ["memory", "logs", "preprompts", "input", "workspace", "archive"]
+    )
     freeze_at(monkeypatch, datetime.datetime(2022, 8, 14, 8, 5, 12))
     archive(dbs)
     assert not os.path.exists(tmp_path / "memory")

--- a/tests/steps/test_archive.py
+++ b/tests/steps/test_archive.py
@@ -29,15 +29,11 @@ def test_archive(tmp_path, monkeypatch):
     freeze_at(monkeypatch, datetime.datetime(2020, 12, 25, 17, 5, 55))
     archive(dbs)
     assert not os.path.exists(tmp_path / "memory")
-    assert os.path.exists(tmp_path / "workspace")
     assert os.path.isdir(tmp_path / "archive" / "20201225_170555")
 
-    dbs = setup_dbs(
-        tmp_path, ["memory", "logs", "preprompts", "input", "workspace", "archive"]
-    )
+    dbs = setup_dbs(tmp_path, ["memory", "logs", "preprompts", "input", "archive"])
     freeze_at(monkeypatch, datetime.datetime(2022, 8, 14, 8, 5, 12))
     archive(dbs)
     assert not os.path.exists(tmp_path / "memory")
-    assert os.path.exists(tmp_path / "workspace")
     assert os.path.isdir(dbs.archive.path / "20201225_170555")
     assert os.path.isdir(dbs.archive.path / "20220814_080512")

--- a/tests/steps/test_archive.py
+++ b/tests/steps/test_archive.py
@@ -29,7 +29,7 @@ def test_archive(tmp_path, monkeypatch):
     freeze_at(monkeypatch, datetime.datetime(2020, 12, 25, 17, 5, 55))
     archive(dbs)
     assert not os.path.exists(tmp_path / "memory")
-    assert not os.path.exists(tmp_path / "workspace")
+    assert os.path.exists(tmp_path / "workspace")
     assert os.path.isdir(tmp_path / "archive" / "20201225_170555")
 
     dbs = setup_dbs(
@@ -38,6 +38,6 @@ def test_archive(tmp_path, monkeypatch):
     freeze_at(monkeypatch, datetime.datetime(2022, 8, 14, 8, 5, 12))
     archive(dbs)
     assert not os.path.exists(tmp_path / "memory")
-    assert not os.path.exists(tmp_path / "workspace")
-    assert os.path.isdir(tmp_path / "archive" / "20201225_170555")
-    assert os.path.isdir(tmp_path / "archive" / "20220814_080512")
+    assert os.path.exists(tmp_path / "workspace")
+    assert os.path.isdir(dbs.archive.path / "20201225_170555")
+    assert os.path.isdir(dbs.archive.path / "20220814_080512")


### PR DESCRIPTION
This will let folder structure look like so:

```
- .gpt_eng
  - archive
  - memory
- prompt
- [all the generateed code files ("workspace") stored on the top level]
```

It will also stop archiving the workspace – think we should instead version control all the project code via git and let gpt-engineer make commits directly after it generates something.

Waiting to merge until we have a good way to "merge in" the generated code into the existing code: #650 