### PR TITLE
Store full file path in workspace

### DIFF
--- a/gpt_engineer/chat_to_files.py
+++ b/gpt_engineer/chat_to_files.py
@@ -92,8 +92,8 @@ def overwrite_files(chat, dbs):
                 "LAST_MODIFICATION_README.md"
             ] = file_content  # TODO store this in memory db instead
         else:
-            dbs.workspace[file_name] = file_content
-
+            full_path = os.path.join(dbs.input.path, file_name)
+            dbs.workspace[full_path] = file_content            
 
 def get_code_strings(input: DB) -> dict[str, str]:
     """


### PR DESCRIPTION
Previously, only the file name was stored in the workspace. This commit changes the behavior to store the full file path instead. This will help in locating the file more accurately in the workspace. The full path is generated using the os.path.join method.