### PR TITLE
Handle undefined additional_information in agent protocol api implementation

### DIFF
--- a/gpt_engineer/api.py
+++ b/gpt_engineer/api.py
@@ -41,7 +41,7 @@ async def task_handler(task: Task) -> None:
         task_id=task.task_id,
         name="create_code",
         is_last=True,
-        additional_properties=task.additional_input.__root__,
+        additional_properties=task.additional_input.__root__ if task.additional_input is not None else None,
     )
 
 
@@ -52,16 +52,26 @@ async def step_handler(step: Step) -> Step:
     Improve code mode is not yet supported, but it would not be much work to support it.
     A list of 'focus' files would need to be submitted in: task.additional_input.
     """
-
-    main(
-        f"projects/{step.task_id}",  # we could also make this an option
-        step.additional_properties.get("model", "gpt-4"),
-        step.additional_properties.get("temperature", 0.1),
-        "benchmark",  # this needs to be headless mode
-        False,
-        step.additional_properties.get("azure_endpoint", ""),
-        step.additional_properties.get("verbose", False),
-    )
+    if step.additional_properties is not None:
+        main(
+            f"projects/{step.task_id}",  # we could also make this an option
+            step.additional_properties.get("model", "gpt-4"),
+            step.additional_properties.get("temperature", 0.1),
+            "benchmark",  # this needs to be headless mode
+            False,
+            step.additional_properties.get("azure_endpoint", ""),
+            step.additional_properties.get("verbose", False),
+        )
+    else:
+        main(
+            project_path=f"projects/{step.task_id}",
+            model="gpt-4",
+            temperature=0.1,
+            steps_config="benchmark",  # this needs to be headless mode
+            improve_option=False,
+            azure_endpoint="",
+            verbose=False,
+        )
 
     return step
 

--- a/gpt_engineer/api.py
+++ b/gpt_engineer/api.py
@@ -41,7 +41,9 @@ async def task_handler(task: Task) -> None:
         task_id=task.task_id,
         name="create_code",
         is_last=True,
-        additional_properties=task.additional_input.__root__ if task.additional_input is not None else None,
+        additional_properties=task.additional_input.__root__
+        if task.additional_input is not None
+        else None,
     )
 
 

--- a/gpt_engineer/api.py
+++ b/gpt_engineer/api.py
@@ -43,7 +43,7 @@ async def task_handler(task: Task) -> None:
         is_last=True,
         additional_properties=task.additional_input.__root__
         if task.additional_input is not None
-        else None,
+        else {},
     )
 
 
@@ -54,26 +54,16 @@ async def step_handler(step: Step) -> Step:
     Improve code mode is not yet supported, but it would not be much work to support it.
     A list of 'focus' files would need to be submitted in: task.additional_input.
     """
-    if step.additional_properties is not None:
-        main(
-            f"projects/{step.task_id}",  # we could also make this an option
-            step.additional_properties.get("model", "gpt-4"),
-            step.additional_properties.get("temperature", 0.1),
-            "benchmark",  # this needs to be headless mode
-            False,
-            step.additional_properties.get("azure_endpoint", ""),
-            step.additional_properties.get("verbose", False),
-        )
-    else:
-        main(
-            project_path=f"projects/{step.task_id}",
-            model="gpt-4",
-            temperature=0.1,
-            steps_config="benchmark",  # this needs to be headless mode
-            improve_option=False,
-            azure_endpoint="",
-            verbose=False,
-        )
+
+    main(
+        f"projects/{step.task_id}",  # we could also make this an option
+        step.additional_properties.get("model", "gpt-4"),
+        step.additional_properties.get("temperature", 0.1),
+        "benchmark",  # this needs to be headless mode
+        False,
+        step.additional_properties.get("azure_endpoint", ""),
+        step.additional_properties.get("verbose", False),
+    )
 
     return step
 


### PR DESCRIPTION
Got errors when using the API for the AutoGPT benchmarks, because the GETs dont include the additional_information property. This PR fixes that issue.