### PR TITLE
Fixing a Link in the Docs

### DIFF
--- a/docs/open_models.md
+++ b/docs/open_models.md
@@ -1,7 +1,7 @@
 Using with open/local models
 ============================
 
-You can integrate `gpt-engineer` with open-source models by leveraging an OpenAI-compatible API. One such API is provided by the [text-generator-ui _extension_ openai](https://github.com/oobabooga/text-generation-webui/blob/main/extensions/openai/README.md>).
+You can integrate `gpt-engineer` with open-source models by leveraging an OpenAI-compatible API. One such API is provided by the [text-generator-ui _extension_ openai](https://github.com/oobabooga/text-generation-webui/blob/main/extensions/openai/README.md).
 
 Setup
 -----


### PR DESCRIPTION
There was a trailing `>` in this link that borked it.

Dope project, btw.