### PR TITLE
Print which directory gpt-engineer is using

### DIFF
--- a/gpt_engineer/main.py
+++ b/gpt_engineer/main.py
@@ -63,6 +63,8 @@ def main(
     )
 
     input_path = Path(project_path).absolute()
+    print("Running gpt-engineer in", input_path, "\n")
+
     workspace_path = input_path / "workspace"
     project_metadata_path = input_path / ".gpteng"
     memory_path = project_metadata_path / "memory"


### PR DESCRIPTION
Makes it clearer where we are actually running, especially if we're run without an explicit path as it defaults to `projects/example`