### PR TITLE
Fix: AI-generated file path issues with -i

### DIFF
--- a/gpt_engineer/chat_to_files.py
+++ b/gpt_engineer/chat_to_files.py
@@ -141,4 +141,6 @@ def format_file_to_input(file_name: str, file_content: str) -> str:
     {file_content}
     ```
     """
+    # Remove workspace\ from the context to prevent nesting another workspace folder
+    file_str = file_str.replace("workspace\\", "")
     return file_str


### PR DESCRIPTION
Remove `workspace\` from the `file_list.txt` context to prevent nesting another workspace folder.

Could do this a dozen ways. 
Core issue: GPT would state filenames as `workspace\...` causing new file creation and no overwrites.