### PR TITLE
Add W&B tracing user guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Welcome to GPT-ENGINEER's Documentation
    readme_link
    windows_readme_link
    open_models.md
+   tracing_debugging.md
 
 
 .. toctree::

--- a/docs/tracing_debugging.md
+++ b/docs/tracing_debugging.md
@@ -19,4 +19,3 @@ Debug and trace the execution of the AI generated code to compare across differe
 
 Automatically capture and save terminal `stdout` to one easily accessible and shareable webpage
 ![](https://drive.google.com/uc?id=1gVva7ZfpwbTSBsnNvId6iq09Gw5ETOks)
-

--- a/docs/tracing_debugging.md
+++ b/docs/tracing_debugging.md
@@ -1,0 +1,22 @@
+Tracing and Debugging with Weights and Biases
+============================
+
+## **[How to store results in Weights & Biases]()**
+
+W&B Prompts is a suite of LLMOps tools built for the development of LLM-powered applications. Use W&B Prompts to visualize and inspect the execution flow of your LLMs, analyze the inputs and outputs of your LLMs, view the intermediate results and securely store and manage your prompts and LLM chain configurations. Read more at https://docs.wandb.ai/guides/prompts
+
+```shell
+ $ export WANDB_API_KEY="YOUR-KEY"
+ $ export LANGCHAIN_WANDB_TRACING=true
+ ```
+
+Sign up for free at https://wandb.ai
+
+
+Debug and trace the execution of the AI generated code to compare across different experiments with `gpt-engineer` and related prompts
+![](https://drive.google.com/uc?id=10wuLwyPbH00CoESsS2Q2q6mkdrtS91jd)
+
+
+Automatically capture and save terminal `stdout` to one easily accessible and shareable webpage
+![](https://drive.google.com/uc?id=1gVva7ZfpwbTSBsnNvId6iq09Gw5ETOks)
+


### PR DESCRIPTION
An updated form of https://github.com/AntonOsika/gpt-engineer/pull/701 where the tracing/debugging how to would be placed in the `user guides`