### PR TITLE
Fix: Crashes after entering additional questions

### DIFF
--- a/gpt_engineer/core/ai.py
+++ b/gpt_engineer/core/ai.py
@@ -342,12 +342,11 @@ class AI:
         """
         data = json.loads(jsondictstr)
         # Modify implicit is_chunk property to ALWAYS false
-        # since Langchain's Message schema is more strict
-        modified_data = [
+        # since Langchain's Message schema is stricter
+        prevalidated_data = [
             {**item, "data": {**item["data"], "is_chunk": False}} for item in data
         ]
-        jsondictstr = json.dumps(modified_data)  # assign to original JSON string
-        return list(messages_from_dict(json.loads(jsondictstr)))  # type: ignore
+        return list(messages_from_dict(prevalidated_data))  # type: ignore
 
     def update_token_usage_log(
         self, messages: List[Message], answer: str, step_name: str

--- a/gpt_engineer/core/ai.py
+++ b/gpt_engineer/core/ai.py
@@ -340,6 +340,11 @@ class AI:
         List[Message]
             The deserialized list of messages.
         """
+        data = json.loads(jsondictstr)
+        # Modify implicit is_chunk property to ALWAYS false
+        # since Langchain's Message schema is more strict
+        modified_data = [{**item, 'data': {**item['data'], 'is_chunk': False}} for item in data]
+        jsondictstr = json.dumps(modified_data)
         return list(messages_from_dict(json.loads(jsondictstr)))  # type: ignore
 
     def update_token_usage_log(

--- a/gpt_engineer/core/ai.py
+++ b/gpt_engineer/core/ai.py
@@ -343,8 +343,10 @@ class AI:
         data = json.loads(jsondictstr)
         # Modify implicit is_chunk property to ALWAYS false
         # since Langchain's Message schema is more strict
-        modified_data = [{**item, 'data': {**item['data'], 'is_chunk': False}} for item in data]
-        jsondictstr = json.dumps(modified_data)
+        modified_data = [
+            {**item, "data": {**item["data"], "is_chunk": False}} for item in data
+        ]
+        jsondictstr = json.dumps(modified_data)  # assign to original JSON string
         return list(messages_from_dict(json.loads(jsondictstr)))  # type: ignore
 
     def update_token_usage_log(


### PR DESCRIPTION
Fixes #754. 

### Cause: 
From a recent Langchain update, it seems the AIMessage object has a much stricter schema which only allows `is_chunk` attributes to have a `False` value. However, in gpt_engineer, the deserialization of `clarify` logs implicitly sets `is_chunk` to `True`. 

### Proposed fixes:
1. Either go to Langchain (or Pydantic which they use internally for model validation of their types) and loosen their requirements for an AIMessage object model. They may or may not agree with my proposal. 
2. Make it explicit that when message objects are deserialized from the  JSON string, that their `is_chunk` attribute can never be `True`. 

### Containment/Fix: 
I go with **Fix 2**. 
This commit deserializes and stores an intermediate list, from which we explicitly set all `is_chunk` values to `False`. Since the Langchain messages_from_dict(..) method anyways expect a Message object with an `is_chunk` property of `False`, we don't have the effect of hotfixing this property, but rather add an additional check to make sure Messages have valid properties (like this is_chunk property for e.g.).
