### PR TITLE
Bugfix/broken module references

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -95,4 +95,3 @@ Functions
     core.steps.setup_sys_prompt_existing_code
     core.steps.simple_gen
     core.steps.use_feedback
-	

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -4,100 +4,10 @@
 API Reference
 =============
 
-:mod:`gpt_engineer.ai`: Ai
-===========================
-
-.. automodule:: gpt_engineer.ai
-    :no-members:
-    :no-inherited-members:
-
-Functions
---------------
-.. currentmodule:: gpt_engineer
-
-.. autosummary::
-    :toctree: ai
-
-    ai.create_chat_model
-    ai.fallback_model
-    ai.get_tokenizer
-    ai.serialize_messages
-
-:mod:`gpt_engineer.api`: Api
+:mod:`gpt_engineer.cli`: Cli
 =============================
 
-.. automodule:: gpt_engineer.api
-    :no-members:
-    :no-inherited-members:
-
-Functions
---------------
-.. currentmodule:: gpt_engineer
-
-.. autosummary::
-    :toctree: api
-
-    api.step_handler
-    api.task_handler
-
-:mod:`gpt_engineer.chat_to_files`: Chat To Files
-=================================================
-
-.. automodule:: gpt_engineer.chat_to_files
-    :no-members:
-    :no-inherited-members:
-
-Functions
---------------
-.. currentmodule:: gpt_engineer
-
-.. autosummary::
-    :toctree: chat_to_files
-
-    chat_to_files.format_file_to_input
-    chat_to_files.get_code_strings
-    chat_to_files.overwrite_files
-    chat_to_files.parse_chat
-    chat_to_files.to_files
-
-:mod:`gpt_engineer.collect`: Collect
-=====================================
-
-.. automodule:: gpt_engineer.collect
-    :no-members:
-    :no-inherited-members:
-
-Functions
---------------
-.. currentmodule:: gpt_engineer
-
-.. autosummary::
-    :toctree: collect
-
-    collect.collect_learnings
-    collect.send_learning
-    collect.steps_file_hash
-
-:mod:`gpt_engineer.db`: Db
-===========================
-
-.. automodule:: gpt_engineer.db
-    :no-members:
-    :no-inherited-members:
-
-Functions
---------------
-.. currentmodule:: gpt_engineer
-
-.. autosummary::
-    :toctree: db
-
-    db.archive
-
-:mod:`gpt_engineer.file_selector`: File Selector
-=================================================
-
-.. automodule:: gpt_engineer.file_selector
+.. automodule:: gpt_engineer.cli
     :no-members:
     :no-inherited-members:
 
@@ -106,66 +16,40 @@ Classes
 .. currentmodule:: gpt_engineer
 
 .. autosummary::
-    :toctree: file_selector
+    :toctree: cli
     :template: class.rst
 
-    file_selector.DisplayablePath
+    cli.file_selector.DisplayablePath
 
 Functions
 --------------
 .. currentmodule:: gpt_engineer
 
 .. autosummary::
-    :toctree: file_selector
+    :toctree: cli
 
-    file_selector.ask_for_files
-    file_selector.gui_file_selector
-    file_selector.is_in_ignoring_extensions
-    file_selector.terminal_file_selector
+    cli.collect.collect_learnings
+    cli.collect.send_learning
+    cli.collect.steps_file_hash
+    cli.file_selector.ask_for_files
+    cli.file_selector.gui_file_selector
+    cli.file_selector.is_in_ignoring_extensions
+    cli.file_selector.terminal_file_selector
+    cli.learning.ask_if_can_store
+    cli.learning.check_consent
+    cli.learning.collect_consent
+    cli.learning.extract_learning
+    cli.learning.get_session
+    cli.learning.human_review_input
+    cli.learning.logs_to_string
+    cli.main.load_env_if_needed
+    cli.main.main
+    cli.main.preprompts_path
 
-:mod:`gpt_engineer.learning`: Learning
-=======================================
-
-.. automodule:: gpt_engineer.learning
-    :no-members:
-    :no-inherited-members:
-
-Functions
---------------
-.. currentmodule:: gpt_engineer
-
-.. autosummary::
-    :toctree: learning
-
-    learning.ask_if_can_store
-    learning.check_consent
-    learning.collect_consent
-    learning.extract_learning
-    learning.get_session
-    learning.human_review_input
-    learning.logs_to_string
-
-:mod:`gpt_engineer.main`: Main
+:mod:`gpt_engineer.core`: Core
 ===============================
 
-.. automodule:: gpt_engineer.main
-    :no-members:
-    :no-inherited-members:
-
-Functions
---------------
-.. currentmodule:: gpt_engineer
-
-.. autosummary::
-    :toctree: main
-
-    main.load_env_if_needed
-    main.main
-
-:mod:`gpt_engineer.steps`: Steps
-=================================
-
-.. automodule:: gpt_engineer.steps
+.. automodule:: gpt_engineer.core
     :no-members:
     :no-inherited-members:
 
@@ -174,35 +58,41 @@ Classes
 .. currentmodule:: gpt_engineer
 
 .. autosummary::
-    :toctree: steps
+    :toctree: core
     :template: class.rst
 
-    steps.Config
+    core.steps.Config
 
 Functions
 --------------
 .. currentmodule:: gpt_engineer
 
 .. autosummary::
-    :toctree: steps
+    :toctree: core
 
-    steps.assert_files_ready
-    steps.clarify
-    steps.curr_fn
-    steps.execute_entrypoint
-    steps.fix_code
-    steps.gen_clarified_code
-    steps.gen_code_after_unit_tests
-    steps.gen_entrypoint
-    steps.gen_spec
-    steps.gen_unit_tests
-    steps.get_improve_prompt
-    steps.human_review
-    steps.improve_existing_code
-    steps.lite_gen
-    steps.respec
-    steps.set_improve_filelist
-    steps.setup_sys_prompt
-    steps.setup_sys_prompt_existing_code
-    steps.simple_gen
-    steps.use_feedback
+    core.ai.create_chat_model
+    core.ai.fallback_model
+    core.ai.get_tokenizer
+    core.ai.serialize_messages
+    core.chat_to_files.format_file_to_input
+    core.chat_to_files.get_code_strings
+    core.chat_to_files.overwrite_files
+    core.chat_to_files.parse_chat
+    core.chat_to_files.to_files
+    core.db.archive
+    core.steps.assert_files_ready
+    core.steps.clarify
+    core.steps.curr_fn
+    core.steps.execute_entrypoint
+    core.steps.gen_clarified_code
+    core.steps.gen_entrypoint
+    core.steps.get_improve_prompt
+    core.steps.human_review
+    core.steps.improve_existing_code
+    core.steps.lite_gen
+    core.steps.set_improve_filelist
+    core.steps.setup_sys_prompt
+    core.steps.setup_sys_prompt_existing_code
+    core.steps.simple_gen
+    core.steps.use_feedback
+

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -95,4 +95,3 @@ Functions
     core.steps.setup_sys_prompt_existing_code
     core.steps.simple_gen
     core.steps.use_feedback
-

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -95,3 +95,4 @@ Functions
     core.steps.setup_sys_prompt_existing_code
     core.steps.simple_gen
     core.steps.use_feedback
+	

--- a/docs/open_models.md
+++ b/docs/open_models.md
@@ -16,7 +16,7 @@ Once the API is set up, you can find the host and the exposed TCP port by checki
 Then, you can use the port and host to run the following example using WizardCoder-Python-34B hosted on Runpod:
 
 ```
-  OPENAI_API_BASE=http://<host>:<port>/v1 python -m gpt_engineer.main benchmark/pomodoro_timer --steps benchmark TheBloke_WizardCoder-Python-34B-V1.0-GPTQ
+  OPENAI_API_BASE=http://<host>:<port>/v1 python -m gpt_engineer.cli.main benchmark/pomodoro_timer --steps benchmark TheBloke_WizardCoder-Python-34B-V1.0-GPTQ
 ```
 
 Using Azure models

--- a/evals/evals_existing_code.py
+++ b/evals/evals_existing_code.py
@@ -54,7 +54,7 @@ def single_evaluate(eval_ob: dict) -> list[bool]:
             "python",
             "-u",  # Unbuffered output
             "-m",
-            "gpt_engineer.main",
+            "gpt_engineer.cli.main",
             eval_ob["project_root"],
             "--steps",
             "eval_improve_code",

--- a/evals/evals_new_code.py
+++ b/evals/evals_new_code.py
@@ -43,7 +43,7 @@ def single_evaluate(eval_ob: dict) -> list[bool]:
             "python",
             "-u",  # Unbuffered output
             "-m",
-            "gpt_engineer.main",
+            "gpt_engineer.cli.main",
             eval_ob["project_root"],
             "--steps",
             "eval_new_code",

--- a/gpt_engineer/core/chat_to_files.py
+++ b/gpt_engineer/core/chat_to_files.py
@@ -14,7 +14,7 @@ Dependencies:
 - `os` and `pathlib`: For handling OS-level operations and path manipulations.
 - `re`: For regex-based parsing of chat content.
 - `gpt_engineer.core.db`: Database handling functionalities for the workspace.
-- `gpt_engineer.file_selector`: Constants related to file selection.
+- `gpt_engineer.cli.file_selector`: Constants related to file selection.
 
 Functions:
 - parse_chat: Extracts code blocks from chat messages.

--- a/gpt_engineer/core/steps.py
+++ b/gpt_engineer/core/steps.py
@@ -8,7 +8,7 @@ workflow execution, and interaction with AI, allowing for various configurations
 Imports:
 - Standard libraries: inspect, re, subprocess
 - Additional libraries/packages: termcolor, typing, enum
-- Internal modules/packages: langchain.schema, gpt_engineer.core, gpt_engineer.file_selector, gpt_engineer.learning
+- Internal modules/packages: langchain.schema, gpt_engineer.core, gpt_engineer.cli
 
 Key Features:
 - Dynamic system prompt creation for both new code generation and improving existing code.

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -37,7 +37,7 @@ def main(
                     "python",
                     "-u",  # Unbuffered output
                     "-m",
-                    "gpt_engineer.main",
+                    "gpt_engineer.cli.main",
                     bench_folder,
                     "--steps",
                     "benchmark",
@@ -69,7 +69,7 @@ def main(
                 [
                     "python",
                     "-m",
-                    "gpt_engineer.main",
+                    "gpt_engineer.cli.main",
                     bench_folder,
                     "--steps",
                     "evaluate",


### PR DESCRIPTION
Found some broken references when trying to run benchmarking - left over from the refactor into core and cli modules 

First commit and not a python person so apologies in advance if this is wrong - but it works on my machine :) 

I regenerated the api_reference.rst too 
