### PR TITLE
Bugfix - CLI - Resolves error "ModuleNotFoundError: No module named 'gpt_engineer.cli'"

### DIFF
--- a/gpt_engineer/__init__.py
+++ b/gpt_engineer/__init__.py
@@ -1,0 +1,8 @@
+# Adding convenience imports to the package
+from gpt_engineer.core import (
+    ai,
+    domain,
+    chat_to_files,
+    steps,
+    db,
+)

--- a/gpt_engineer/cli/__init__.py
+++ b/gpt_engineer/cli/__init__.py
@@ -1,0 +1,15 @@
+"""
+gpt_engineer.cli
+-----------------
+
+The CLI package for the GPT Engineer project, providing the command line interface
+for the application.
+
+Modules:
+    - main: The primary CLI module for GPT Engineer.
+    - collect: Collect send learning data for analysis and improvement.
+    - file_selector: Selecting files using GUI and terminal-based file explorer.
+    - learning: Tools and data structures for data collection.
+
+For more specific details, refer to the docstrings within each module.
+"""

--- a/gpt_engineer/core/__init__.py
+++ b/gpt_engineer/core/__init__.py
@@ -14,11 +14,3 @@ Modules:
 
 For more specific details, refer to the docstrings within each module.
 """
-
-from gpt_engineer.core import (
-    ai,
-    domain,
-    chat_to_files,
-    steps,
-    db,
-)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ gpt-engineer = 'gpt_engineer.cli.main:app'
 ge = 'gpt_engineer.cli.main:app'
 
 [tool.setuptools]
-packages = ["gpt_engineer", "gpt_engineer.cli"]
+packages = ["gpt_engineer", "gpt_engineer.cli", "gpt_engineer.core"]
 
 [tool.ruff]
 select = ["F", "E", "W", "I001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ gpt-engineer = 'gpt_engineer.cli.main:app'
 ge = 'gpt_engineer.cli.main:app'
 
 [tool.setuptools]
-packages = ["gpt_engineer"]
+packages = ["gpt_engineer", "gpt_engineer.cli"]
 
 [tool.ruff]
 select = ["F", "E", "W", "I001"]


### PR DESCRIPTION
Resolves cli bug resulting from refactoring in #766.  Bug errors as follows:
```bash
ModuleNotFoundError: No module named 'gpt_engineer.cli'
```

