### PR TITLE
Adding tests for refactored CLI

### DIFF
--- a/gpt_engineer/__init__.py
+++ b/gpt_engineer/__init__.py
@@ -1,0 +1,8 @@
+# Adding convenience imports to the package
+from gpt_engineer.core import (
+    ai,
+    domain,
+    chat_to_files,
+    steps,
+    db,
+)

--- a/gpt_engineer/cli/__init__.py
+++ b/gpt_engineer/cli/__init__.py
@@ -1,0 +1,15 @@
+"""
+gpt_engineer.cli
+-----------------
+
+The CLI package for the GPT Engineer project, providing the command line interface
+for the application.
+
+Modules:
+    - main: The primary CLI module for GPT Engineer.
+    - collect: Collect send learning data for analysis and improvement.
+    - file_selector: Selecting files using GUI and terminal-based file explorer.
+    - learning: Tools and data structures for data collection.
+
+For more specific details, refer to the docstrings within each module.
+"""

--- a/gpt_engineer/core/__init__.py
+++ b/gpt_engineer/core/__init__.py
@@ -14,11 +14,3 @@ Modules:
 
 For more specific details, refer to the docstrings within each module.
 """
-
-from gpt_engineer.core import (
-    ai,
-    domain,
-    chat_to_files,
-    steps,
-    db,
-)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ gpt-engineer = 'gpt_engineer.cli.main:app'
 ge = 'gpt_engineer.cli.main:app'
 
 [tool.setuptools]
-packages = ["gpt_engineer", "gpt_engineer.cli"]
+packages = ["gpt_engineer", "gpt_engineer.cli", "gpt_engineer.core"]
 
 [tool.ruff]
 select = ["F", "E", "W", "I001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ gpt-engineer = 'gpt_engineer.cli.main:app'
 ge = 'gpt_engineer.cli.main:app'
 
 [tool.setuptools]
-packages = ["gpt_engineer"]
+packages = ["gpt_engineer", "gpt_engineer.cli"]
 
 [tool.ruff]
 select = ["F", "E", "W", "I001"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,7 +1,31 @@
 """
-Tests for successful import of the package and its modules
+Tests for successful import and installation of the package.
 """
-import traceback
+import subprocess
+import sys
+import venv
+import shutil
+
+# Test that the package can be installed via pip
+def test_installation():
+    # Create a virtual environment
+    venv_dir = "./venv_test_installation"
+    venv.create(venv_dir, with_pip=True)
+
+    # Use pip from the virtual environment directly
+    pip_executable = f"{venv_dir}/bin/pip"
+    if sys.platform == "win32":
+        pip_executable = f"{venv_dir}/Scripts/pip.exe"
+    
+    try:
+        result = subprocess.run(
+            [pip_executable, "install", "."], 
+            capture_output=True
+        )
+        assert result.returncode == 0, f"Install via pip failed: {result.stderr.decode()}"
+    finally:
+        # Cleanup
+        shutil.rmtree(venv_dir)
 
 
 # Test that the package can be imported
@@ -15,5 +39,4 @@ def test_import():
             db,
         )
     except ImportError as e:
-        # tb = traceback.format_exc()
         assert False, f"Failed to import {e.name}"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6,27 +6,22 @@ import sys
 import venv
 import shutil
 
+# Setup the test environment
+VENV_DIR = "./venv_test_installation"
+venv.create(VENV_DIR, with_pip=True)
+
 # Test that the package can be installed via pip
 def test_installation():
-    # Create a virtual environment
-    venv_dir = "./venv_test_installation"
-    venv.create(venv_dir, with_pip=True)
-
     # Use pip from the virtual environment directly
-    pip_executable = f"{venv_dir}/bin/pip"
+    pip_executable = f"{VENV_DIR}/bin/pip"
     if sys.platform == "win32":
-        pip_executable = f"{venv_dir}/Scripts/pip.exe"
+        pip_executable = f"{VENV_DIR}/Scripts/pip.exe"
     
-    try:
-        result = subprocess.run(
-            [pip_executable, "install", "."], 
-            capture_output=True
-        )
-        assert result.returncode == 0, f"Install via pip failed: {result.stderr.decode()}"
-    finally:
-        # Cleanup
-        shutil.rmtree(venv_dir)
-
+    result = subprocess.run(
+        [pip_executable, "install", "."], 
+        capture_output=True
+    )
+    assert result.returncode == 0, f"Install via pip failed: {result.stderr.decode()}"
 
 # Test that the package can be imported
 def test_import():
@@ -40,3 +35,25 @@ def test_import():
         )
     except ImportError as e:
         assert False, f"Failed to import {e.name}"
+
+# Test that the CLI command works
+def test_cli_execution():
+    # This assumes that after installation, `gpt-engineer` command should work.
+    result = subprocess.run(
+        args=["gpt-engineer", "--help"], 
+        capture_output=True, 
+        text=True
+        )
+    assert result.returncode == 0, f"gpt-engineer command failed with message: {result.stderr}"
+
+# Cleanup the test environment
+def test_cleanup():
+    shutil.rmtree(VENV_DIR)
+
+
+# Run the tests using pytest
+if __name__ == "__main__":
+    test_installation()
+    test_import()
+    test_cli_execution()
+    test_cleanup()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -10,18 +10,17 @@ import shutil
 VENV_DIR = "./venv_test_installation"
 venv.create(VENV_DIR, with_pip=True)
 
+
 # Test that the package can be installed via pip
 def test_installation():
     # Use pip from the virtual environment directly
     pip_executable = f"{VENV_DIR}/bin/pip"
     if sys.platform == "win32":
         pip_executable = f"{VENV_DIR}/Scripts/pip.exe"
-    
-    result = subprocess.run(
-        [pip_executable, "install", "."], 
-        capture_output=True
-    )
+
+    result = subprocess.run([pip_executable, "install", "."], capture_output=True)
     assert result.returncode == 0, f"Install via pip failed: {result.stderr.decode()}"
+
 
 # Test that the package can be imported
 def test_import():
@@ -36,15 +35,17 @@ def test_import():
     except ImportError as e:
         assert False, f"Failed to import {e.name}"
 
+
 # Test that the CLI command works
 def test_cli_execution():
     # This assumes that after installation, `gpt-engineer` command should work.
     result = subprocess.run(
-        args=["gpt-engineer", "--help"], 
-        capture_output=True, 
-        text=True
-        )
-    assert result.returncode == 0, f"gpt-engineer command failed with message: {result.stderr}"
+        args=["gpt-engineer", "--help"], capture_output=True, text=True
+    )
+    assert (
+        result.returncode == 0
+    ), f"gpt-engineer command failed with message: {result.stderr}"
+
 
 # Cleanup the test environment
 def test_cleanup():

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,19 @@
+"""
+Tests for successful import of the package and its modules
+"""
+import traceback
+
+
+# Test that the package can be imported
+def test_import():
+    try:
+        from gpt_engineer import (
+            ai,
+            domain,
+            chat_to_files,
+            steps,
+            db,
+        )
+    except ImportError as e:
+        # tb = traceback.format_exc()
+        assert False, f"Failed to import {e.name}"


### PR DESCRIPTION
Given the bug surfaced and resolved with PR #778, added tests to cover this and related cases in the future.

Created 3 tests (and cleanup utility function) in test_install.py:
* Test that the package can be installed (locally) using `pip`
  * This is done in a virtual environment
  * The virtual environment persists throughout the rest of the tests
* Test that all modules can be imported
  * This tests only the imports of the core modules, as imports of the CLI modules is not recommended or supported (see issue #718)
* Tests that `gpt-engineer` command can be successfully run via the CLI
  * This tests the bug that was resolved in PR #778 and related bugs

After test execution, the virtual environment is removed.

I could use some guidance on how to separate this PR -- which I'm raising from the `refactored-cli-tests` branch which contains only the 3 CLI-related test addition commits -- from the other PR (#778) / branch that I created to solve the bug (branch `bugfix-cli-20231009`).   When I check the git log for the tests branch, I only see the 3 commits I want as part of this PR (which build on the other PR, admittedly).

![image](https://github.com/AntonOsika/gpt-engineer/assets/366332/cc3b3524-610a-4a06-beb6-66856c44d69d)

I hope I've done this right!  Please share any comments or guidance.