### PR TITLE
feat: add caching and benchmark

### DIFF
--- a/gpt_engineer/cli/main.py
+++ b/gpt_engineer/cli/main.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import openai
 import typer
 from dotenv import load_dotenv
+from parea import init, RedisCache
 
 from gpt_engineer.core.ai import AI
 from gpt_engineer.core.db import DB, DBs, archive
@@ -40,6 +41,12 @@ from gpt_engineer.cli.collect import collect_learnings
 from gpt_engineer.cli.learning import collect_consent
 
 app = typer.Typer()  # creates a CLI app
+
+
+# set this to True to use caching of LLM calls and being able to benchmark function across many inputs in parallel
+IS_DEV = True
+if IS_DEV:
+    init(cache=RedisCache())
 
 
 def load_env_if_needed():

--- a/gpt_engineer/cli/main.py
+++ b/gpt_engineer/cli/main.py
@@ -30,9 +30,9 @@ import os
 from pathlib import Path
 
 import openai
+from parea import init, RedisCache
 import typer
 from dotenv import load_dotenv
-from parea import init, RedisCache
 
 from gpt_engineer.core.ai import AI
 from gpt_engineer.core.db import DB, DBs, archive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   'python-dotenv >= 0.21.0',
   'langchain >=0.0.240',
   'agent-protocol==1.0.1',
+  'parea-ai >= 0.2.10',
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   'python-dotenv >= 0.21.0',
   'langchain >=0.0.240',
   'agent-protocol==1.0.1',
-  'parea-ai >= 0.2.10',
+  'parea-ai >= 0.2.11',
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   'python-dotenv >= 0.21.0',
   'langchain >=0.0.240',
   'agent-protocol==1.0.1',
-  'parea-ai >= 0.2.11',
+  'parea-ai >= 0.2.12',
 ]
 
 classifiers = [


### PR DESCRIPTION
Hey, I opened a PR which allows you to quickly iterate on your app locally.

Adding the `init` statement will automatically use a local redis cache for any of your LLM requests (more [here](https://github.com/parea-ai/parea-sdk-py#debugging-chains--agents)). With that you won't need to wait for the slow & expensive API requests if you make any changes to your code/prompts and want to make sure everything works as expected.

This will also enable you to test gpt-engineer across many inputs at the same time via:

```bash
parea benchmark --func gpt_engineer/cli/main:main --csv_path benchmark-inputs.csv
```

The benchmark will create a CSV file with all the traces for you to debug.

I ran the benchmark with this CSV file:
```csv
project_path,model,temperature,steps_config,improve_mode,lite_mode,azure_endpoint,use_custom_preprompts,verbose
"projects/example1","gpt-4",0.1,"default","","","","",""
"projects/example2","gpt-4",0.5,"default","","","","",""
```