### PR TITLE
(Docs) Add support for Llama2, Claude, Palm, Cohere, Replicate (100+ LLMs)

### DIFF
--- a/docs/open_models.md
+++ b/docs/open_models.md
@@ -37,7 +37,7 @@ Using Anthropic,Huggingface,Palm,Ollama, etc. [Full List](https://docs.litellm.a
 We'll use [LiteLLM](https://docs.litellm.ai/docs/) to create an OpenAI-compatible endpoint, that translates OpenAI calls to any of the [supported providers](https://docs.litellm.ai/docs/providers).
 
 
-Example to use a local CodeLLama model from Ollama.ai with GPT-Engineer: 
+Example to use a local CodeLLama model from Ollama.ai with GPT-Engineer:
 
 Let's spin up a proxy server to route any OpenAI call from GPT-Engineer to Ollama/CodeLlama
 

--- a/docs/open_models.md
+++ b/docs/open_models.md
@@ -29,3 +29,31 @@ Then you call `gpt-engineer` with your service endpoint `--azure https://aoi-res
 
 Example:
 `gpt-engineer --azure https://myairesource.openai.azure.com ./projects/example/ my-gpt4-project-name`
+
+Using Anthropic,Huggingface,Palm,Ollama, etc. [Full List](https://docs.litellm.ai/docs/providers)
+==================
+
+### Create OpenAI-proxy
+We'll use [LiteLLM](https://docs.litellm.ai/docs/) to create an OpenAI-compatible endpoint, that translates OpenAI calls to any of the [supported providers](https://docs.litellm.ai/docs/providers).
+
+
+Example to use a local CodeLLama model from Ollama.ai with GPT-Engineer: 
+
+Let's spin up a proxy server to route any OpenAI call from GPT-Engineer to Ollama/CodeLlama
+
+```python
+pip install litellm
+```
+```python
+$ litellm --model ollama/codellama
+
+#INFO: Ollama running on http://0.0.0.0:8000
+```
+
+[Docs](https://docs.litellm.ai/docs/proxy_server)
+
+### Update GPT-Engineer
+
+```
+  OPENAI_API_BASE=http://0.0.0.0:8000 python -m gpt-engineer projects/my-new-project
+```


### PR DESCRIPTION
Hey @AntonOsika, 

Based on your feedback on this PR - https://github.com/AntonOsika/gpt-engineer/pull/660, 

My PR shows users how to call their custom LLM providers (bedrock, togetherai, huggingface tgi, replicate, ai21, cohere, ai21 etc.) by pointing the api base to a [local proxy](https://docs.litellm.ai/docs/proxy_server) they can use for experimentation with GPT-Engineer.

This makes **no code changes** to GPT-Engineer.

Happy to add additional tests/documentation if the initial PR looks good.