### PR TITLE
Support for OpenAI Base API Integration

### DIFF
--- a/gpt_engineer/cli/main.py
+++ b/gpt_engineer/cli/main.py
@@ -43,11 +43,15 @@ app = typer.Typer()  # creates a CLI app
 
 
 def load_env_if_needed(openai_api_base: str):
+    
     if openai_api_base:
-        openai.api_key = os.getenv("OPENAI_API_KEY")
-        # Should set to Empty key would work but its not working, Finding the solution.
+        openai.api_key = ""
+        # API Key is optional in case of Proxy servers (https://docs.litellm.ai/docs/proxy_server#replace-openai-base), 
+        # But in current situation its not working with empty key
+        # Finding another solutions here.
         return
-    elif os.getenv("OPENAI_API_KEY") is None:
+    
+    if os.getenv("OPENAI_API_KEY") is None:
         load_dotenv()
         if os.getenv("OPENAI_API_KEY") is None:
             # if there is no .env file, try to load from the current working directory

--- a/gpt_engineer/cli/main.py
+++ b/gpt_engineer/cli/main.py
@@ -45,11 +45,11 @@ app = typer.Typer()  # creates a CLI app
 def load_env_if_needed(openai_api_base: str):
     
     if openai_api_base:
-        openai.api_key = ""
+        #openai.api_key = None
         # API Key is optional in case of Proxy servers (https://docs.litellm.ai/docs/proxy_server#replace-openai-base), 
         # But in current situation its not working with empty key
         # Finding another solutions here.
-        return
+        pass
     
     if os.getenv("OPENAI_API_KEY") is None:
         load_dotenv()

--- a/gpt_engineer/cli/main.py
+++ b/gpt_engineer/cli/main.py
@@ -44,8 +44,8 @@ app = typer.Typer()  # creates a CLI app
 
 def load_env_if_needed(openai_api_base: str):
     if openai_api_base:
-        #os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
         openai.api_key = os.getenv("OPENAI_API_KEY")
+        # Should set to Empty key would work but its not working, Finding the solution.
         return
     elif os.getenv("OPENAI_API_KEY") is None:
         load_dotenv()

--- a/gpt_engineer/cli/main.py
+++ b/gpt_engineer/cli/main.py
@@ -45,10 +45,10 @@ app = typer.Typer()  # creates a CLI app
 def load_env_if_needed(openai_api_base: str):
     
     if openai_api_base:
-        #openai.api_key = None
-        # API Key is optional in case of Proxy servers (https://docs.litellm.ai/docs/proxy_server#replace-openai-base), 
-        # But in current situation its not working with empty key
-        # Finding another solutions here.
+        # The API key may be optional in certain scenarios, such as when using proxy servers.
+        # 1. Authenticated Servers: These servers necessitate the use of an API key, typically authenticated via OAuth.
+        # 2. Unauthenticated Servers: These servers do not require an API key for access.
+        # Therefore, it is crucial to accommodate both scenarios in this section of the code.
         pass
     
     if os.getenv("OPENAI_API_KEY") is None:

--- a/gpt_engineer/core/ai.py
+++ b/gpt_engineer/core/ai.py
@@ -126,7 +126,7 @@ class AI:
         Count the total number of tokens in a list of messages.
     """
 
-    def __init__(self, model_name="gpt-4", temperature=0.1, azure_endpoint=""):
+    def __init__(self, model_name: str, temperature: float,azure_endpoint: Optional[str] = None,openai_api_base: Optional[str] = None):
         """
         Initialize the AI class.
 
@@ -151,6 +151,9 @@ class AI:
         self.cumulative_completion_tokens = 0
         self.cumulative_total_tokens = 0
         self.token_usage_log = []
+        self.openai_api_base = openai_api_base
+        
+        
 
     def start(self, system: str, user: str, step_name: str) -> List[Message]:
         """
@@ -170,6 +173,7 @@ class AI:
         List[Message]
             The list of messages in the conversation.
         """
+        openai.api_base = self.openai_api_base or openai.api_base
         messages: List[Message] = [
             SystemMessage(content=system),
             HumanMessage(content=user),
@@ -523,7 +527,7 @@ def create_chat_model(self, model: str, temperature) -> BaseChatModel:
     return ChatOpenAI(
         model=model,
         temperature=temperature,
-        streaming=True,
+        streaming=False,
         client=openai.ChatCompletion,
     )
 

--- a/gpt_engineer/core/ai.py
+++ b/gpt_engineer/core/ai.py
@@ -527,9 +527,9 @@ def create_chat_model(self, model: str, temperature) -> BaseChatModel:
     return ChatOpenAI(
         model=model,
         temperature=temperature,
-        streaming=False,
+        streaming=True,
         client=openai.ChatCompletion,
-        openai_api_base=self.openai_api_base
+        openai_api_base=self.openai_api_base,
     )
 
 

--- a/gpt_engineer/core/ai.py
+++ b/gpt_engineer/core/ai.py
@@ -126,7 +126,7 @@ class AI:
         Count the total number of tokens in a list of messages.
     """
 
-    def __init__(self, model_name: str, temperature: float,azure_endpoint: Optional[str] = None,openai_api_base: Optional[str] = None):
+    def __init__(self, model_name: str="gpt-4", temperature: float = 0.1,azure_endpoint: Optional[str] = "",openai_api_base: Optional[str] = ""):
         """
         Initialize the AI class.
 

--- a/gpt_engineer/core/ai.py
+++ b/gpt_engineer/core/ai.py
@@ -139,6 +139,7 @@ class AI:
         """
         self.temperature = temperature
         self.azure_endpoint = azure_endpoint
+        self.openai_api_base = openai_api_base
         self.model_name = (
             fallback_model(model_name) if azure_endpoint == "" else model_name
         )
@@ -151,7 +152,6 @@ class AI:
         self.cumulative_completion_tokens = 0
         self.cumulative_total_tokens = 0
         self.token_usage_log = []
-        self.openai_api_base = openai_api_base
         
         
 
@@ -529,6 +529,7 @@ def create_chat_model(self, model: str, temperature) -> BaseChatModel:
         temperature=temperature,
         streaming=False,
         client=openai.ChatCompletion,
+        openai_api_base=self.openai_api_base
     )
 
 


### PR DESCRIPTION
This PR introduces a feature mentioned [here]( https://github.com/AntonOsika/gpt-engineer/issues/710)

This feature introduces the capability for users to integrate their own **OpenAI Base API**. Currently, our system is reliant on the OpenAI's primary API Base. Given the associated costs and the availability of different models such as _GPT 3.5 and GPT 4_, it's imperative to provide an alternative. By allowing users to supply their own base API, we can potentially offer more cost-effective or even complimentary access to **GPT** models. This can be configured through a dedicated settings file, enabling users to utilize the **GPT Engineer** with their preferred version of **GPT**.

The command to Run GPT-Engineer using Custom base API.
```python
python -m gpt_engineer.cli.main projects/example 'gpt-4' --openai-api-base https://heaven-gpt.haseebmir.repl.co
```

**Current Configuration:**
1. The **API Base** is configured via the command line option `--openai-api-base`.
2. ~~At present, the streaming functionality is *deactivated*.~~ Updated the **Streaming response** now.
3. It's mandatory to set the **API Key** using the `.env` (Environment) file.

**Proposed Enhancements:**
1. ~~Implement a mechanism to modify the **API Base** for both streaming and non-streaming responses.~~ Updated in **latest PR**.
2. Allow the **API Key** to default to *Empty* when a specific base API is chosen. While this is feasible with LiteLLM, it presents challenges with LangChain and OpenAI. I am exploring more solutions to address this.
I have created this issue on LangChain about this here [LangChain OpenAI API Key Optional](https://github.com/langchain-ai/langchain/issues/11700) check it out.
3. Ask user to provide Authentication information for its own API server.
Details like `Is server Authenticated with API Key` and with this details we can make changes in codebase.

**_Test use cases for servers._**
**Custom** API servers can be of two types:

- **Authenticated**: These servers require users to authenticate themselves using a mechanism such as OAuth or API keys. This ensures that only authorized users can access the API.

- **Unauthenticated**: These servers do not require any authentication. This means that anyone can access the API, which can be a security risk.

I have only tested with **Unauthenticated** _server_ as i only have single server to test, and to make sure we cover all server we need to test the both server for our use case here.
