### PR TITLE
restricting langchain version to <=0.0.312

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   'tiktoken >=0.0.4',
   'tabulate == 0.9.0',
   'python-dotenv >= 0.21.0',
-  'langchain >=0.0.240',
+  'langchain >=0.0.240, <=0.0.312',
   'agent-protocol==1.0.1',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   'tiktoken >=0.0.4',
   'tabulate == 0.9.0',
   'python-dotenv >= 0.21.0',
-  'langchain >=0.0.240, <=0.0.312',
+  'langchain >=0.0.240, <=0.0.312', # The upper bound is to address AiMessageChunk problem in bug report 802 and 804 on GH. If we want/need to relax this in the future, we should check that the AiMessageChunk error has been resolved.
   'agent-protocol==1.0.1',
 ]
 


### PR DESCRIPTION
This solves the AiMessageChunk problem in bug report 802 and 804