### PR TITLE
Fix leftover ai.fuser() call on self_heal

### DIFF
--- a/gpt_engineer/core/steps.py
+++ b/gpt_engineer/core/steps.py
@@ -720,10 +720,10 @@ def self_heal(ai: AI, dbs: FileRepositories):
             # the gen_entrypoint prompt inside.
             if attempts < 1:
                 messages = AI.deserialize_messages(dbs.logs[gen_entrypoint.__name__])
-                messages.append(ai.fuser(get_platform_info()))  # add in OS and Py version
+                messages.append(HumanMessage(content=get_platform_info()))  # add in OS and Py version
 
             # append the error message
-            messages.append(ai.fuser(dbs.workspace["log.txt"]))
+            messages.append(HumanMessage(content=f"{dbs.workspace['log.txt']}"))
 
             messages = ai.next(
                 messages, dbs.preprompts["file_format_fix"], step_name=curr_fn()

--- a/gpt_engineer/core/steps.py
+++ b/gpt_engineer/core/steps.py
@@ -720,8 +720,9 @@ def self_heal(ai: AI, dbs: FileRepositories):
             # the gen_entrypoint prompt inside.
             if attempts < 1:
                 messages = AI.deserialize_messages(dbs.logs[gen_entrypoint.__name__])
-                messages.append(HumanMessage(content=get_platform_info()))  # add in OS and Py version
-
+                messages.append(
+                    HumanMessage(content=get_platform_info())
+                )  # add in OS and Py version
             # append the error message
             messages.append(HumanMessage(content=f"{dbs.workspace['log.txt']}"))
 


### PR DESCRIPTION
There is a leftover call to `ai.fuser()` on the `self_heal` step that prevent using the step with error 
```
Traceback (most recent call last):
  File "/usr/local/bin/gpt-engineer", line 8, in <module>
    sys.exit(app())
  File "/app/gpt_engineer/cli/main.py", line 186, in main
    messages = step(ai, fileRepositories)
  File "/app/gpt_engineer/core/steps.py", line 723, in self_heal
    messages.append(ai.fuser(get_platform_info()))  # add in OS and Py version
AttributeError: 'AI' object has no attribute 'fuser'
```
fix is making the change to use `HumanMessage` function directly like on other steps