### PR TITLE
build: added cloc Makefile target to easily count loc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,7 @@ run:
 	@echo -e "$(COLOR_CYAN)Running GPT Engineer on $(COLOR_GREEN)$(name)$(COLOR_CYAN) folder...$(COLOR_RESET)" && \
 	source venv/bin/activate && \
 	gpt-engineer projects/$(name)
+
+# Counts the lines of code in the project
+cloc:
+	cloc . --exclude-dir=node_modules,dist,build,.mypy_cache,benchmark --exclude-list-file=.gitignore --fullpath --not-match-d='docs/_build' --by-file


### PR DESCRIPTION
Just a tiny cloc make target to easily count loc in the project. I found it useful to understand where complexity hides.