### PR TITLE
feat: added new gpte command for better ux

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,20 @@ There are two ways to work with GPT-engineer: new code mode (the default), and i
 ### Creating new code
 - Create an empty folder for your project anywhere on your computer
 - Create a file called `prompt` (no extension) inside your new folder and fill it with instructions
-- Run `gpt-engineer <project_dir>` with a relative path to your folder
-  - For example: `gpt-engineer projects/my-new-project` from the gpt-engineer directory root with your new folder in `projects/`
+- Run `gpte <project_dir>` with a relative path to your folder
+  - For example: `gpte projects/my-new-project` from the gpt-engineer directory root with your new folder in `projects/`
 
 ### Improving Existing Code
 - Locate a folder with code which you want to improve anywhere on your computer
 - Create a file called `prompt` (no extension) inside your new folder and fill it with instructions for how you want to improve the code
-- Run `gpt-engineer <project_dir> -i` with a relative path to your folder
-  - For example: `gpt-engineer projects/my-old-project` from the gpt-engineer directory root with your folder in `projects/`
+- Run `gpte <project_dir> -i` with a relative path to your folder
+  - For example: `gpte projects/my-old-project` from the gpt-engineer directory root with your folder in `projects/`
 
 By running gpt-engineer you agree to our [terms](https://github.com/AntonOsika/gpt-engineer/blob/main/TERMS_OF_USE.md).
+
+### Note
+
+- To run this tool, the new command `gpte` is recommended for better user experience. However, the earlier default commands `gpt-engineer` and `ge` are also supported.
 
 
 ## Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ sphinx_copybutton = ">=0.5.2"
 [tool.poetry.scripts]
 gpt-engineer = 'gpt_engineer.applications.cli.main:app'
 ge = 'gpt_engineer.applications.cli.main:app'
+gpte = 'gpt_engineer.applications.cli.main:app'
 bench = 'gpt_engineer.benchmark.__main__:main'
 
 [tool.poetry.extras]


### PR DESCRIPTION
### Why this PR?
The existing commands `gpt-engineer` and `ge` to run the tool are not very optimal. Here's why.

- `gpt-engineer` command is too cumbersome and contains a hyphen which is not very easy to type. The command is too long as well.
- `ge` command is too vague and is not very memorable and doesn't directly correlate with the name of the tool i.e. 'gpt-engineer'.

### Basis for the new command
The new command suggested and implemented in this PR is `gpte`. Here's the reasoning behind this.

- Memorability and Pronunciation: The acronym `gpte` clearly stems from the initial letters of gpt-engineer, making it memorable. It's also easy to pronounce, which could make verbal communication about the tool more straightforward.
- Length and Typing Ease: `gpte` strikes a balance between being too long and too short. It avoids the ambiguity of a two-letter acronym like `ge` while not being as cumbersome as the full `gpt-engineer`.
- Avoiding Conflicts: Shorter commands like `ge` could potentially conflict with existing or future commands in the UNIX environment. `gpte` is unique enough to avoid such conflicts, while still being relevant to gpt-engineer.
- Consistency with CLI Practices: Many CLI tools use shortened versions of their names for commands (`git`, `npm`, etc.). `gpte` follows this convention, making it a logical choice for users familiar with such patterns.
- Conveys Purpose: While `ge` could be too vague, `gpte` maintains a clear connection to the purpose of the tool. Users are likely to associate the command with the GPT-related functionalities it provides.

### References

- CLI naming conventions  - https://clig.dev/#naming