### PR TITLE
Remove excess whitespace in files included in context.

### DIFF
--- a/gpt_engineer/core/chat_to_files.py
+++ b/gpt_engineer/core/chat_to_files.py
@@ -175,11 +175,11 @@ def format_file_to_input(file_name: str, file_content: str) -> str:
         The formatted file string.
     """
     file_str = f"""
-    {file_name}
-    ```
-    {file_content}
-    ```
-    """
+{file_name}
+```
+{file_content}
+```
+"""
     return file_str
 
 


### PR DESCRIPTION
This PR fixes a bug causing files included in the LLM context to be formatted in a weird way.

Using the current code, a file will be formatted like this:
```
    main.jsx
    ```
    import React from "react";
import ReactDOM from "react-dom/client";
import App from "./App.jsx";
import "./index.css";

ReactDOM.createRoot(document.getElementById("root")).render(
  <React.StrictMode>
    <App />
  </React.StrictMode>
);

    ```
```

Note the extra indentation at the first three lines and the last line, which I think may be confusing for the LLM (and even if it isn't confusing, it wastes a handful of tokens).