### PR TITLE
ci: use Python 3.10 in linting & testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,17 +1,9 @@
 name: Poetry install and pytest
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - "**.py"
-      - "**.yaml"
-      - "**.yml"
   push:
     branches: [ main ]
-    paths:
-      - "**.py"
-      - "**.yaml"
-      - "**.yml"
+  pull_request:
+    branches: [ main ]
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.8"
           cache: 'poetry'
 
       # Install dependencies using Poetry

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
           cache: 'poetry'
 
       # Install dependencies using Poetry

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ GPT Engineer is made to be easy to adapt, extend, and make your agent learn how 
 
 ## Setup
 
-This project supports Python 3.8 - 3.11.
+This project supports Python 3.10 - 3.11.
 
 Choose either **stable** or **development**.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,12 +81,12 @@ experimental = ["llama-index", "rank-bm25", "tree_sitter_languages"]
 [tool.ruff]
 select = ["F", "E", "W", "I001"]
 show-fixes = false
-target-version = "py311"
+target-version = "py38"
 task-tags = ["TODO", "FIXME"]
 extend-ignore = ["E501", "E722"]
 
 [tool.black]
-target-version = ["py311"]
+target-version = ["py38"]
 
 [tool.ruff.isort]
 known-first-party = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,12 +81,12 @@ experimental = ["llama-index", "rank-bm25", "tree_sitter_languages"]
 [tool.ruff]
 select = ["F", "E", "W", "I001"]
 show-fixes = false
-target-version = "py38"
+target-version = "py310"
 task-tags = ["TODO", "FIXME"]
 extend-ignore = ["E501", "E722"]
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py310"]
 
 [tool.ruff.isort]
 known-first-party = []


### PR DESCRIPTION
As requested in https://github.com/AntonOsika/gpt-engineer/issues/898#issuecomment-1858797037

Build will fail and linters will scream until the occurrences of `type1 | type2` is replaced with `Union[type1, type2]`.

Waiting for @similato87 to make the changes requested in https://github.com/AntonOsika/gpt-engineer/issues/898#issuecomment-1858796974