### PR TITLE
Replace the 3.10 style type hints with the traditional style.

### DIFF
--- a/gpt_engineer/applications/cli/cli_agent.py
+++ b/gpt_engineer/applications/cli/cli_agent.py
@@ -1,4 +1,4 @@
-from typing import Callable, TypeVar, Optional
+from typing import Callable, Optional, TypeVar
 
 # from gpt_engineer.core.default.git_version_manager import GitVersionManager
 from gpt_engineer.core.ai import AI
@@ -123,7 +123,10 @@ class CliAgent(BaseAgent):
         return files_dict
 
     def improve(
-        self, files_dict: FilesDict, prompt: str, execution_command: Optional[str] = None
+        self,
+        files_dict: FilesDict,
+        prompt: str,
+        execution_command: Optional[str] = None,
     ) -> FilesDict:
         files_dict = self.improve_fn(
             self.ai, prompt, files_dict, self.memory, self.preprompts_holder

--- a/gpt_engineer/applications/cli/cli_agent.py
+++ b/gpt_engineer/applications/cli/cli_agent.py
@@ -1,4 +1,4 @@
-from typing import Callable, TypeVar
+from typing import Callable, TypeVar, Optional
 
 # from gpt_engineer.core.default.git_version_manager import GitVersionManager
 from gpt_engineer.core.ai import AI
@@ -123,7 +123,7 @@ class CliAgent(BaseAgent):
         return files_dict
 
     def improve(
-        self, files_dict: FilesDict, prompt: str, execution_command: str | None = None
+        self, files_dict: FilesDict, prompt: str, execution_command: Optional[str] = None
     ) -> FilesDict:
         files_dict = self.improve_fn(
             self.ai, prompt, files_dict, self.memory, self.preprompts_holder

--- a/gpt_engineer/applications/cli/learning.py
+++ b/gpt_engineer/applications/cli/learning.py
@@ -89,7 +89,7 @@ TERM_CHOICES = (
 )
 
 
-def human_review_input() -> Review | None:
+def human_review_input() -> Optional[Review]:
     """
     Ask the user to review the generated code and return their review.
 

--- a/gpt_engineer/core/base_execution_env.py
+++ b/gpt_engineer/core/base_execution_env.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from subprocess import Popen
+from typing import Optional
 
 from gpt_engineer.core.files_dict import FilesDict
 
@@ -19,7 +20,7 @@ class BaseExecutionEnv(ABC):
     """
 
     @abstractmethod
-    def run(self, command: str, timeout: int | None = None) -> tuple[str, str, int]:
+    def run(self, command: str, timeout: Optional[int] = None) -> tuple[str, str, int]:
         """
         Runs a command in the execution environment.
         """

--- a/gpt_engineer/core/base_memory.py
+++ b/gpt_engineer/core/base_memory.py
@@ -1,4 +1,4 @@
 from pathlib import Path
-from typing import MutableMapping
+from typing import MutableMapping, Union
 
-BaseMemory = MutableMapping[str | Path, str]
+BaseMemory = MutableMapping[Union[str, Path], str]

--- a/gpt_engineer/core/default/disk_execution_env.py
+++ b/gpt_engineer/core/default/disk_execution_env.py
@@ -2,6 +2,7 @@ import subprocess
 import time
 
 from pathlib import Path
+from typing import Union, Optional
 
 from gpt_engineer.core.base_execution_env import BaseExecutionEnv
 from gpt_engineer.core.default.file_store import FileStore
@@ -20,7 +21,7 @@ class DiskExecutionEnv(BaseExecutionEnv):
         path (str): The file system path where the code is located and will be executed.
     """
 
-    def __init__(self, path: str | Path | None = None):
+    def __init__(self, path: Union[str, Path, None] = None):
         self.store = FileStore(path)
 
     def upload(self, files: FilesDict) -> "DiskExecutionEnv":
@@ -40,7 +41,7 @@ class DiskExecutionEnv(BaseExecutionEnv):
         )
         return p
 
-    def run(self, command: str, timeout: int | None = None) -> tuple[str, str, int]:
+    def run(self, command: str, timeout: Optional[int] = None) -> tuple[str, str, int]:
         start = time.time()
         print("\n--- Start of run ---")
         # while running, also print the stdout and stderr

--- a/gpt_engineer/core/default/disk_execution_env.py
+++ b/gpt_engineer/core/default/disk_execution_env.py
@@ -2,7 +2,7 @@ import subprocess
 import time
 
 from pathlib import Path
-from typing import Union, Optional
+from typing import Optional, Union
 
 from gpt_engineer.core.base_execution_env import BaseExecutionEnv
 from gpt_engineer.core.default.file_store import FileStore

--- a/gpt_engineer/core/default/disk_memory.py
+++ b/gpt_engineer/core/default/disk_memory.py
@@ -247,7 +247,7 @@ class DiskMemory(BaseMemory):
         else:
             return self._all_files()
 
-    def to_dict(self) -> Dict[str | Path, str]:
+    def to_dict(self) -> Dict[Union[str, Path], str]:
         return {file_path: self[file_path] for file_path in self}
 
     def to_json(self) -> str:

--- a/gpt_engineer/core/default/file_store.py
+++ b/gpt_engineer/core/default/file_store.py
@@ -1,12 +1,13 @@
 import tempfile
 
 from pathlib import Path
+from typing import Union
 
 from gpt_engineer.core.files_dict import FilesDict
 
 
 class FileStore:
-    def __init__(self, path: str | Path | None = None):
+    def __init__(self, path: Union[str, Path, None] = None):
         if path is None:
             path = Path(tempfile.mkdtemp(prefix="gpt-engineer-"))
 

--- a/gpt_engineer/core/default/simple_agent.py
+++ b/gpt_engineer/core/default/simple_agent.py
@@ -1,4 +1,5 @@
 import tempfile
+
 from typing import Optional
 
 from gpt_engineer.core.ai import AI

--- a/gpt_engineer/core/default/simple_agent.py
+++ b/gpt_engineer/core/default/simple_agent.py
@@ -1,4 +1,5 @@
 import tempfile
+from typing import Optional
 
 from gpt_engineer.core.ai import AI
 from gpt_engineer.core.base_agent import BaseAgent
@@ -61,7 +62,7 @@ class SimpleAgent(BaseAgent):
         self,
         files_dict: FilesDict,
         prompt: str,
-        execution_command: str | None = None,
+        execution_command: Optional[str] = None,
     ) -> FilesDict:
         files_dict = improve(
             self.ai, prompt, files_dict, self.memory, self.preprompts_holder

--- a/gpt_engineer/core/files_dict.py
+++ b/gpt_engineer/core/files_dict.py
@@ -31,7 +31,7 @@ class FilesDict(dict):
         value : str
             The code content to associate with the filename.
         """
-        if not isinstance(key, str | Path):
+        if not isinstance(key, (str, Path)):
             raise TypeError("Keys must be strings or Path's")
         if not isinstance(value, str):
             raise TypeError("Values must be strings")


### PR DESCRIPTION
Refactor: Replaced Python 3.10 style type hints with traditional Optional syntax for broader compatibility for https://github.com/AntonOsika/gpt-engineer/issues/898.
